### PR TITLE
replace withHeaders call with seperate header calls

### DIFF
--- a/src/SecureHeadersMiddleware.php
+++ b/src/SecureHeadersMiddleware.php
@@ -20,9 +20,11 @@ class SecureHeadersMiddleware
     {
         $response = $next($request);
 
-        $response->withHeaders(
-            (new SecureHeaders(config('secure-headers', [])))->headers()
-        );
+        $headers = (new SecureHeaders(config('secure-headers', [])))->headers();
+
+        foreach($headers as $name => $content) {
+            $response->header($name, $content);
+        }
 
         return $response;
     }


### PR DESCRIPTION
Hi there! 

I've been using this package since a couple of months and it works great, thanks for your work!

Today I tried to install it on an older project that runs on Laravel 5.1. The only problem I've encountered is that the Laravel middleware uses the new `withHeaders` method. This method isn't available in 5.1 but the same functionality can easily be replaced by making multiple calls to the `header` method.

This PR fixes this issue. It provides better backwards compatibility without any downsides. 

Let me know if I can help or if you have any feedback on this request.

Thanks again for your work,

Barry