### PR TITLE
Don't handle request when the response is instance of StreamedResponse

### DIFF
--- a/src/SecureHeadersMiddleware.php
+++ b/src/SecureHeadersMiddleware.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class SecureHeadersMiddleware
 {
@@ -21,8 +22,8 @@ class SecureHeadersMiddleware
     {
         $response = $next($request);
 
-        // when response is BinaryFileResponse, we should not add headers
-        if ($response instanceof BinaryFileResponse) {
+        // when response is BinaryFileResponse or StreamedResponse, we should not add headers
+        if ($response instanceof BinaryFileResponse || $response instanceof StreamedResponse) {
             return $response;
         }
 


### PR DESCRIPTION
Fixes the `Call to undefined method Symfony\Component\HttpFoundation\StreamedResponse::header()` error on responses of type `StreamedResponse`. The `StreamedResponse` has no header() method.
Fixes #7