### PR TITLE
Generate nonce value for CSP header

### DIFF
--- a/config/secure-headers.php
+++ b/config/secure-headers.php
@@ -156,6 +156,8 @@ return [
             'unsafe-inline' => false,
 
             'unsafe-eval' => false,
+
+            'add-generated-nonce' => true,
         ],
 
         'style-src' => [
@@ -163,9 +165,15 @@ return [
                 //
             ],
 
+            'nonces' => [
+                //
+            ],
+
             'self' => false,
 
             'unsafe-inline' => false,
+
+            'add-generated-nonce' => true,
         ],
 
         'img-src' => [

--- a/src/SecureHeaders.php
+++ b/src/SecureHeaders.php
@@ -211,7 +211,7 @@ class SecureHeaders
     {
         static $nonce;
 
-        if (!isset($nonce)) {
+        if (! isset($nonce)) {
             $nonce = self::generateNonce();
         }
 


### PR DESCRIPTION
## Config
The CSP header allows for nonce-values on the `style-src` and `script-src` directives. Both these directives have a new configuration option:
```php
'add-generated-nonce' => true,
```

This option will generate a unique and secure nonce value for that request and add it to the nonces of that directive.

## Usage
The generated nonce can be used to "whitelist" unsafe (i.e. inline and eval) styles and scripts. 

Retrieve the nonce for this request:
```php
$nonce = SecureHeaders::nonce();
``` 

Set the nonce-attribute on the script or style tag:
```html
<style type="text/css" nonce="{{$nonce}}">
  // ...
</style>
<script type="text/javascript" nonce="{{$nonce}}">
  // ....
</script>
```
