### PR TITLE
Fix for the HSTS-Markup

### DIFF
--- a/src/SecureHeaders.php
+++ b/src/SecureHeaders.php
@@ -152,11 +152,13 @@ class SecureHeaders
             return [];
         }
 
-        $hsts = "max-age={$this->config['hsts']['max-age']}; preload;";
+        $hsts = "max-age={$this->config['hsts']['max-age']};";
 
         if ($this->config['hsts']['include-sub-domains']) {
             $hsts .= ' includeSubDomains;';
         }
+
+        $hsts .= " preload";
 
         return [
             'Strict-Transport-Security' => $hsts,


### PR DESCRIPTION
TLDR;
the last semicolon was obsolete.

## PreStory
Checked my site with this [tool](https://hstspreload.org/?domain=enaah.de) and the submission failed because the Markup wasn't correct.


- The Required Markup (after the [RFC6769](https://tools.ietf.org/html/rfc6797)):
`Strict-Transport-Security: max-age=63072000; includeSubDomains; preload`

- The provides Markup from this package:
`Strict-Transport-Security: max-age=63072000; includeSubDomains; preload;`

Conlusion: remove the last `;`
