### PR TITLE
Fix "preload" markup - HSTS rules

### DIFF
--- a/src/SecureHeaders.php
+++ b/src/SecureHeaders.php
@@ -152,11 +152,13 @@ class SecureHeaders
             return [];
         }
 
-        $hsts = "max-age={$this->config['hsts']['max-age']}; preload;";
+        $hsts = "max-age={$this->config['hsts']['max-age']};";
 
         if ($this->config['hsts']['include-sub-domains']) {
             $hsts .= ' includeSubDomains;';
         }
+
+        $hsts .= " preload";
 
         return [
             'Strict-Transport-Security' => $hsts,

--- a/src/SecureHeaders.php
+++ b/src/SecureHeaders.php
@@ -158,7 +158,7 @@ class SecureHeaders
             $hsts .= ' includeSubDomains;';
         }
 
-        $hsts .= " preload";
+        $hsts .= ' preload';
 
         return [
             'Strict-Transport-Security' => $hsts,

--- a/tests/SecureHeadersTest.php
+++ b/tests/SecureHeadersTest.php
@@ -120,7 +120,7 @@ class SecureHeadersTest extends TestCase
         $headers = (new SecureHeaders($config))->headers();
 
         $this->assertArraySubset([
-            'Strict-Transport-Security' => 'max-age=15552000; preload; includeSubDomains;',
+            'Strict-Transport-Security' => 'max-age=15552000; includeSubDomains; preload',
         ], $headers, true);
     }
 


### PR DESCRIPTION
TLDR;
the last semicolon was obsolete.

## PreStory
Checked my site with this [tool](https://hstspreload.org/?domain=enaah.de) and the submission failed because the Markup wasn't correct.


- The Required Markup (according to [RFC6769](https://tools.ietf.org/html/rfc6797)):
`Strict-Transport-Security: max-age=63072000; includeSubDomains; preload`

- The provided Markup from this package:
`Strict-Transport-Security: max-age=63072000; includeSubDomains; preload;`

Conlusion: remove the last `;`