### PR TITLE
Add configuration to toggle HSTS preload

### DIFF
--- a/config/secure-headers.php
+++ b/config/secure-headers.php
@@ -108,7 +108,7 @@ return [
 
         'include-sub-domains' => false,
 
-        'preload' => false,
+        'preload' => true,
     ],
 
     /*

--- a/config/secure-headers.php
+++ b/config/secure-headers.php
@@ -107,6 +107,8 @@ return [
         'max-age' => 15552000,
 
         'include-sub-domains' => false,
+
+        'preload' => false,
     ],
 
     /*

--- a/src/SecureHeaders.php
+++ b/src/SecureHeaders.php
@@ -165,7 +165,9 @@ class SecureHeaders
             $hsts .= ' includeSubDomains;';
         }
 
-        $hsts .= ' preload';
+        if ($this->config['hsts']['preload'] ?? true) {
+            $hsts .= ' preload';
+        }
 
         return [
             'Strict-Transport-Security' => $hsts,

--- a/src/SecureHeaders.php
+++ b/src/SecureHeaders.php
@@ -159,14 +159,14 @@ class SecureHeaders
             return [];
         }
 
-        $hsts = "max-age={$this->config['hsts']['max-age']};";
+        $hsts = "max-age={$this->config['hsts']['max-age']}";
 
         if ($this->config['hsts']['include-sub-domains']) {
-            $hsts .= ' includeSubDomains;';
+            $hsts .= '; includeSubDomains';
         }
 
         if ($this->config['hsts']['preload'] ?? true) {
-            $hsts .= ' preload';
+            $hsts .= '; preload';
         }
 
         return [

--- a/tests/SecureHeadersTest.php
+++ b/tests/SecureHeadersTest.php
@@ -184,6 +184,21 @@ class SecureHeadersTest extends TestCase
         ], $headers, true);
     }
 
+    public function test_hsts_preload_disabled()
+    {
+        $config = require $this->configPath;
+
+        $config['hsts']['enable'] = true;
+        $config['hsts']['include-sub-domains'] = true;
+        $config['hsts']['preload'] = false;
+
+        $headers = (new SecureHeaders($config))->headers();
+
+        $this->assertArraySubset([
+            'Strict-Transport-Security' => 'max-age=15552000; includeSubDomains',
+        ], $headers, true);
+    }
+
     public function test_expect_ct()
     {
         $config = require $this->configPath;

--- a/tests/SecureHeadersTest.php
+++ b/tests/SecureHeadersTest.php
@@ -170,6 +170,20 @@ class SecureHeadersTest extends TestCase
         ], $headers, true);
     }
 
+    public function test_hsts_preload_not_set()
+    {
+        $config = require __DIR__.'/fixtures/5_3_3/config/secure-headers.php';
+
+        $config['hsts']['enable'] = true;
+        $config['hsts']['include-sub-domains'] = true;
+
+        $headers = (new SecureHeaders($config))->headers();
+
+        $this->assertArraySubset([
+            'Strict-Transport-Security' => 'max-age=15552000; includeSubDomains; preload',
+        ], $headers, true);
+    }
+
     public function test_expect_ct()
     {
         $config = require $this->configPath;

--- a/tests/fixtures/5_3_3/config/secure-headers.php
+++ b/tests/fixtures/5_3_3/config/secure-headers.php
@@ -1,0 +1,522 @@
+<?php
+
+return [
+
+    /*
+     * Server
+     *
+     * Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server
+     *
+     * Note: when server is empty string, it will not add to response header
+     */
+
+    'server' => '',
+
+    /*
+     * X-Content-Type-Options
+     *
+     * Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
+     *
+     * Available Value: 'nosniff'
+     */
+
+    'x-content-type-options' => 'nosniff',
+
+    /*
+     * X-Download-Options
+     *
+     * Reference: https://msdn.microsoft.com/en-us/library/jj542450(v=vs.85).aspx
+     *
+     * Available Value: 'noopen'
+     */
+
+    'x-download-options' => 'noopen',
+
+    /*
+     * X-Frame-Options
+     *
+     * Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
+     *
+     * Available Value: 'deny', 'sameorigin', 'allow-from <uri>'
+     */
+
+    'x-frame-options' => 'sameorigin',
+
+    /*
+     * X-Permitted-Cross-Domain-Policies
+     *
+     * Reference: https://www.adobe.com/devnet/adobe-media-server/articles/cross-domain-xml-for-streaming.html
+     *
+     * Available Value: 'all', 'none', 'master-only', 'by-content-type', 'by-ftp-filename'
+     */
+
+    'x-permitted-cross-domain-policies' => 'none',
+
+    /*
+     * X-XSS-Protection
+     *
+     * Reference: https://blogs.msdn.microsoft.com/ieinternals/2011/01/31/controlling-the-xss-filter
+     *
+     * Available Value: '1', '0', '1; mode=block'
+     */
+
+    'x-xss-protection' => '1; mode=block',
+
+    /*
+     * Referrer-Policy
+     *
+     * Reference: https://w3c.github.io/webappsec-referrer-policy
+     *
+     * Available Value: 'no-referrer', 'no-referrer-when-downgrade', 'origin', 'origin-when-cross-origin',
+     *                  'same-origin', 'strict-origin', 'strict-origin-when-cross-origin', 'unsafe-url'
+     */
+
+    'referrer-policy' => 'no-referrer',
+
+    /*
+     * Clear-Site-Data
+     *
+     * Reference: https://w3c.github.io/webappsec-clear-site-data/
+     */
+
+    'clear-site-data' => [
+        'enable' => false,
+
+        'all' => false,
+
+        'cache' => true,
+
+        'cookies' => true,
+
+        'storage' => true,
+
+        'executionContexts' => true,
+    ],
+
+    /*
+     * HTTP Strict Transport Security
+     *
+     * Reference: https://developer.mozilla.org/en-US/docs/Web/Security/HTTP_strict_transport_security
+     *
+     * Please ensure your website had set up ssl/tls before enable hsts.
+     */
+
+    'hsts' => [
+        'enable' => false,
+
+        'max-age' => 15552000,
+
+        'include-sub-domains' => false,
+    ],
+
+    /*
+     * Expect-CT
+     *
+     * Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Expect-CT
+     */
+
+    'expect-ct' => [
+        'enable' => false,
+
+        'max-age' => 2147483648,
+
+        'enforce' => false,
+
+        'report-uri' => null,
+    ],
+
+    /*
+     * Public Key Pinning
+     *
+     * Reference: https://developer.mozilla.org/en-US/docs/Web/Security/Public_Key_Pinning
+     *
+     * hpkp will be ignored if hashes is empty.
+     */
+
+    'hpkp' => [
+        'hashes' => [
+            // 'sha256-hash-value',
+        ],
+
+        'include-sub-domains' => false,
+
+        'max-age' => 15552000,
+
+        'report-only' => false,
+
+        'report-uri' => null,
+    ],
+
+    /*
+     * Feature Policy
+     *
+     * Reference: https://wicg.github.io/feature-policy/
+     */
+
+    'feature-policy' => [
+        'enable' => true,
+
+        /*
+         * Each directive details can be found on:
+         *
+         * https://github.com/WICG/feature-policy/blob/master/features.md
+         *
+         * 'none', '*' and 'self allow' are mutually exclusive,
+         * the priority is 'none' > '*' > 'self allow'.
+         */
+
+        'autoplay' => [
+            'none' => false,
+
+            '*' => false,
+
+            'self' => true,
+
+            'allow' => [
+                // 'url',
+            ],
+        ],
+
+        'camera' => [
+            'none' => false,
+
+            '*' => false,
+
+            'self' => true,
+
+            'allow' => [
+                // 'url',
+            ],
+        ],
+
+        'encrypted-media' => [
+            'none' => false,
+
+            '*' => false,
+
+            'self' => true,
+
+            'allow' => [
+                // 'url',
+            ],
+        ],
+
+        'fullscreen' => [
+            'none' => false,
+
+            '*' => false,
+
+            'self' => true,
+
+            'allow' => [
+                // 'url',
+            ],
+        ],
+
+        'geolocation' => [
+            'none' => false,
+
+            '*' => false,
+
+            'self' => true,
+
+            'allow' => [
+                // 'url',
+            ],
+        ],
+
+        'microphone' => [
+            'none' => false,
+
+            '*' => false,
+
+            'self' => true,
+
+            'allow' => [
+                // 'url',
+            ],
+        ],
+
+        'midi' => [
+            'none' => false,
+
+            '*' => false,
+
+            'self' => true,
+
+            'allow' => [
+                // 'url',
+            ],
+        ],
+
+        'payment' => [
+            'none' => false,
+
+            '*' => false,
+
+            'self' => true,
+
+            'allow' => [
+                // 'url',
+            ],
+        ],
+
+        'picture-in-picture' => [
+            'none' => false,
+
+            '*' => true,
+
+            'self' => false,
+
+            'allow' => [
+                // 'url',
+            ],
+        ],
+
+        'accelerometer' => [
+            'none' => false,
+
+            '*' => false,
+
+            'self' => true,
+
+            'allow' => [
+                // 'url',
+            ],
+        ],
+
+        'ambient-light-sensor' => [
+            'none' => false,
+
+            '*' => false,
+
+            'self' => true,
+
+            'allow' => [
+                // 'url',
+            ],
+        ],
+
+        'gyroscope' => [
+            'none' => false,
+
+            '*' => false,
+
+            'self' => true,
+
+            'allow' => [
+                // 'url',
+            ],
+        ],
+
+        'magnetometer' => [
+            'none' => false,
+
+            '*' => false,
+
+            'self' => true,
+
+            'allow' => [
+                // 'url',
+            ],
+        ],
+
+        'speaker' => [
+            'none' => false,
+
+            '*' => false,
+
+            'self' => true,
+
+            'allow' => [
+                // 'url',
+            ],
+        ],
+
+        'sync-xhr' => [
+            'none' => false,
+
+            '*' => true,
+
+            'self' => false,
+
+            'allow' => [
+                // 'url',
+            ],
+        ],
+
+        'usb' => [
+            'none' => false,
+
+            '*' => false,
+
+            'self' => true,
+
+            'allow' => [
+                // 'url',
+            ],
+        ],
+
+        'vr' => [
+            'none' => false,
+
+            '*' => false,
+
+            'self' => true,
+
+            'allow' => [
+                // 'url',
+            ],
+        ],
+    ],
+
+    /*
+     * Content Security Policy
+     *
+     * Reference: https://developer.mozilla.org/en-US/docs/Web/Security/CSP
+     *
+     * csp will be ignored if custom-csp is not null. To disable csp, set custom-csp to empty string.
+     *
+     * Note: custom-csp does not support report-only.
+     */
+
+    'custom-csp' => null,
+
+    'csp' => [
+        'report-only' => false,
+
+        'report-uri' => null,
+
+        'block-all-mixed-content' => false,
+
+        'upgrade-insecure-requests' => false,
+
+        /*
+         * Please references script-src directive for available values, only `script-src` and `style-src`
+         * supports `add-generated-nonce`.
+         *
+         * Note: when directive value is empty, it will use `none` for that directive.
+         */
+
+        'script-src' => [
+            'allow' => [
+                // 'url',
+            ],
+
+            'hashes' => [
+                // 'sha256' => [
+                //     'hash-value',
+                // ],
+            ],
+
+            'nonces' => [
+                // 'base64-encoded',
+            ],
+
+            'schemes' => [
+                // 'https:',
+            ],
+
+            'self' => false,
+
+            'unsafe-inline' => false,
+
+            'unsafe-eval' => false,
+
+            'strict-dynamic' => false,
+
+            'unsafe-hashed-attributes' => false,
+
+            // https://www.chromestatus.com/feature/5792234276388864
+            'report-sample' => true,
+
+            'add-generated-nonce' => false,
+        ],
+
+        'style-src' => [
+            'allow' => [
+                //
+            ],
+
+            'hashes' => [
+                // 'sha256' => [
+                //     'hash-value',
+                // ],
+            ],
+
+            'nonces' => [
+                //
+            ],
+
+            'schemes' => [
+                // 'https:',
+            ],
+
+            'self' => false,
+
+            'unsafe-inline' => false,
+
+            'report-sample' => true,
+
+            'add-generated-nonce' => false,
+        ],
+
+        'img-src' => [
+            //
+        ],
+
+        'default-src' => [
+            //
+        ],
+
+        'base-uri' => [
+            //
+        ],
+
+        'connect-src' => [
+            //
+        ],
+
+        'font-src' => [
+            //
+        ],
+
+        'form-action' => [
+            //
+        ],
+
+        'frame-ancestors' => [
+            //
+        ],
+
+        'frame-src' => [
+            //
+        ],
+
+        'manifest-src' => [
+            //
+        ],
+
+        'media-src' => [
+            //
+        ],
+
+        'object-src' => [
+            //
+        ],
+
+        'worker-src' => [
+            //
+        ],
+
+        'plugin-types' => [
+            // 'application/x-shockwave-flash',
+        ],
+
+        'require-sri-for' => '',
+
+        'sandbox' => '',
+
+    ],
+
+];


### PR DESCRIPTION
In order to follow the [recommended deployment](https://hstspreload.org/#deployment-recommendations) of the HSTS header, this PR allows the `preload` directive to be optional. When including the `preload` directive, it is considered to be requesting inclusion in the preload list. This can lead to issues when all subdomains cannot be accessed with HSTS enabled. See all notes at the [HSTS Preload](https://hstspreload.org/) page for additional notes and warnings.

Configuration is set to false as default but the library defaults to true if the preload configuration is missing. This should avoid any backwards-compatibility issues.