### PR TITLE
Add support for Laravel 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ matrix:
     - php: 7.2
       env:
         - TESTBENCH_VERSION=3.8.*
-        - PHPUNIT_VERSION=7.5.
+        - PHPUNIT_VERSION=7.5.*
     - php: 7.2
       env:
         - TESTBENCH_VERSION=4.0.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,13 @@ matrix:
     - php: 7.2
       env:
         - TESTBENCH_VERSION=3.8.*
-        - PHPUNIT_VERSION=7.5.*
+        - PHPUNIT_VERSION=7.5.
+    - php: 7.2
+      env:
+        - TESTBENCH_VERSION=4.0.*
+        - PHPUNIT_VERSION=8.0.*
+
+*
 
     - php: 7.3
       env:
@@ -109,6 +115,11 @@ matrix:
       env:
         - TESTBENCH_VERSION=3.8.*
         - PHPUNIT_VERSION=7.5.*
+    - php: 7.3
+      env:
+        - TESTBENCH_VERSION=4.0.*
+        - PHPUNIT_VERSION=8.0.*
+
 
 install:
   - composer global require hirak/prestissimo --no-suggest --no-interaction --optimize-autoloader
@@ -126,4 +137,4 @@ script: vendor/bin/phpunit
 
 # Commands to be run after your environment runs.
 after_script:
-  - if [ "$TRAVIS_PHP_VERSION" == "7.3" && "$TESTBENCH_VERSION" == "3.8.*" ]; then ./cc-test-reporter after-build --coverage-input-type clover --id $CC_TOKEN --exit-code $TRAVIS_TEST_RESULT; fi
+  - if [ "$TRAVIS_PHP_VERSION" == "7.3" && "$TESTBENCH_VERSION" == "4.0.*" ]; then ./cc-test-reporter after-build --coverage-input-type clover --id $CC_TOKEN --exit-code $TRAVIS_TEST_RESULT; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,8 +81,6 @@ matrix:
         - TESTBENCH_VERSION=4.0.*
         - PHPUNIT_VERSION=8.0.*
 
-*
-
     - php: 7.3
       env:
         - TESTBENCH_VERSION=3.1.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,27 +11,6 @@ cache:
 # Versions of PHP you want your project run with.
 matrix:
   include:
-    - php: 7.0
-      env:
-        - TESTBENCH_VERSION=3.1.*
-        - PHPUNIT_VERSION=5.7.*
-    - php: 7.0
-      env:
-        - TESTBENCH_VERSION=3.2.*
-        - PHPUNIT_VERSION=5.7.*
-    - php: 7.0
-      env:
-        - TESTBENCH_VERSION=3.3.*
-        - PHPUNIT_VERSION=5.7.*
-    - php: 7.0
-      env:
-        - TESTBENCH_VERSION=3.4.*
-        - PHPUNIT_VERSION=6.5.*
-    - php: 7.0
-      env:
-        - TESTBENCH_VERSION=3.5.*
-        - PHPUNIT_VERSION=6.5.*
-
     - php: 7.1
       env:
         - TESTBENCH_VERSION=3.1.*

--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,13 @@
   ],
   "require": {
     "php": "^7.0",
-    "illuminate/support": "~5.1"
+    "illuminate/support": "~5.1|~6.0"
   },
   "require-dev": {
     "ext-xdebug": "*",
-    "orchestra/testbench": "~3.1",
+    "orchestra/testbench": "~3.1|~4.0",
     "phpstan/phpstan": "~0.7",
-    "phpunit/phpunit": "~5.7|~6.5|~7.5"
+    "phpunit/phpunit": "~5.7|~6.5|~7.5|~8.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
- Fixes the composer.json to support laravel 6.0
- Remove PHP 7.0 from travis testing : not officially supported anymore
- Add Orchestra 4.0 and PHPUnit 8.0 to travis testing for PHP 7.2 and  PHP 7.3