### PR TITLE
Do not enable HSTS preload by default

### DIFF
--- a/config/secure-headers.php
+++ b/config/secure-headers.php
@@ -116,7 +116,7 @@ return [
 
         'include-sub-domains' => false,
 
-        'preload' => true,
+        'preload' => false,
     ],
 
     /*


### PR DESCRIPTION
> Preloading Should Be Opt-In
>
>  If you maintain a project that provides HTTPS configuration advice or provides an option to enable HSTS, do not include the preload directive by default. We get regular emails from site operators who tried out HSTS this way, only to find themselves on the preload list by the time they find they need to remove HSTS to access certain subdomains. Removal tends to be slow and painful for those sites.
>
> It's great to support HSTS preloading as a best practice, and for projects to provide a simple option to enable it. However, site operators who enable HSTS should know about the long-term consequences of preloading before they turn it on for a given domain. They should also be informed that they need to meet additional requirements and submit their site to hstspreload.org to ensure that it is successfully preloaded (i.e. to get the full protection of the intended configuration). 

Source: https://hstspreload.org/#opt-in