### PR TITLE
Add support for Laravel 7.0

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -47,7 +47,7 @@ jobs:
         run: composer remove "friendsofphp/php-cs-fixer" "phpstan/phpstan" --dev --no-update
 
       - name: Add Testbench and PHPUnit to dev dependencies
-        run: composer require "orchestra/testbench:^5.0" "phpunit/phpunit:^8.0" --dev --no-interaction --no-suggest --no-update
+        run: composer require "orchestra/testbench:^5.0" "phpunit/phpunit:^8.4" --dev --no-interaction --no-suggest --no-update
 
       - name: Install dependencies
         run: composer update --optimize-autoloader --no-interaction --no-progress --no-suggest

--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -24,6 +24,37 @@ jobs:
       - name: Run PHP-CS-Fixer
         run: vendor/bin/php-cs-fixer fix --verbose --dry-run
 
+  laravel_7_x:
+    runs-on: ${{ matrix.operating-system }}
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        operating-system: [ubuntu-latest, windows-latest, macOS-latest]
+        php-versions: ['7.2', '7.3', '7.4']
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup PHP, Composer and Extensions
+        uses: shivammathur/setup-php@v1
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: dom, fileinfo, mbstring, xdebug
+
+      - name: Remove php-cs-fixer and phpstan
+        run: composer remove "friendsofphp/php-cs-fixer" "phpstan/phpstan" --dev --no-update
+
+      - name: Add Testbench and PHPUnit to dev dependencies
+        run: composer require "orchestra/testbench:^5.0" "phpunit/phpunit:^8.0" --dev --no-interaction --no-suggest --no-update
+
+      - name: Install dependencies
+        run: composer update --optimize-autoloader --no-interaction --no-progress --no-suggest
+
+      - name: Test against Laravel 7.x
+        run: vendor/bin/phpunit
+
   laravel_6_x:
     runs-on: ${{ matrix.operating-system }}
 

--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,13 @@
   ],
   "require": {
     "php": "^7.0",
-    "illuminate/support": "~5.1|~6.0"
+    "illuminate/support": "~5.1|~6.0|~7.0"
   },
   "require-dev": {
     "ext-json": "*",
     "ext-xdebug": "*",
     "friendsofphp/php-cs-fixer": "~2.2",
-    "orchestra/testbench": "~3.1|~4.0",
+    "orchestra/testbench": "~3.1|~4.0|~5.0",
     "phpstan/phpstan": "~0.7",
     "phpunit/phpunit": "~5.7|~6.5|~7.5|~8.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "friendsofphp/php-cs-fixer": "~2.2",
     "orchestra/testbench": "~3.1|~4.0|~5.0",
     "phpstan/phpstan": "~0.7",
-    "phpunit/phpunit": "~5.7|~6.5|~7.5|~8.0"
+    "phpunit/phpunit": "~5.7|~6.5|~7.5|^8.4"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
This adds support for Laravel 7.0 and includes it in the test suite.

You might also consider removing support for the previous versions and tag a new major release that only supports Laravel 7.0+.