### PR TITLE
Add possibility to clear nonces

### DIFF
--- a/src/SecureHeaders.php
+++ b/src/SecureHeaders.php
@@ -263,7 +263,7 @@ class SecureHeaders
     {
         if ($target === null) {
             self::$nonces['script'] = self::$nonces['style'] = [];
-        }else if (isset(self::$nonces[$target])) {
+        } elseif (isset(self::$nonces[$target])) {
             self::$nonces[$target] = [];
         }
     }

--- a/src/SecureHeaders.php
+++ b/src/SecureHeaders.php
@@ -52,7 +52,7 @@ class SecureHeaders
     public function __destruct()
     {
         if ($this->sent) {
-            self::$nonces['script'] = self::$nonces['style'] = [];
+            self::clearNonces();
         }
     }
 
@@ -250,5 +250,21 @@ class SecureHeaders
         self::$nonces[$target][] = $nonce;
 
         return $nonce;
+    }
+
+    /**
+     * Remove all nonces for given target. When is null, all targets are cleared
+     *
+     * @param string|null $target
+     *
+     * @return void
+     */
+    public static function clearNonces(string $target = null)
+    {
+        if ($target === null) {
+            self::$nonces['script'] = self::$nonces['style'] = [];
+        }else if (isset(self::$nonces[$target])) {
+            self::$nonces[$target] = [];
+        }
     }
 }

--- a/tests/SecureHeadersTest.php
+++ b/tests/SecureHeadersTest.php
@@ -149,6 +149,20 @@ final class SecureHeadersTest extends TestCase
         );
     }
 
+    public function testContentSecurityPolicyClearedNonces()
+    {
+        SecureHeaders::nonce();
+
+        SecureHeaders::clearNonces();
+
+        $headers = (new SecureHeaders($this->config()))->headers();
+
+        $this->assertArrayNotHasKey(
+            'Content-Security-Policy',
+            $headers
+        );
+    }
+
     public function testContentSecurityPolicyNonceWillBeClearedAfterHeaderSent()
     {
         $times = 10;


### PR DESCRIPTION
In Laravel app, I have this piece of code `View::share('scpScriptNonceToken', SecureHeaders::nonce());` in AppServiceProvider. I used this to prevent generating a big amount of nonces for scripts.

But there is also another reason for this. On sites when is no JS, no nonce is generated. Which then means that someone is able to inject his own script without nonce and it will work. (This would happen really rarely). This will always generate a nonce.

But then, I need to remove nonces for some routes where libraries like FileManager lives. Currently, there is no way how to remove already generated nonces.

---

Hope this is understandable. If not, don't hesitate to ask