### PR TITLE
Add csp_nonce helper function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,10 @@
   "autoload": {
     "psr-4": {
       "Bepsvpt\\SecureHeaders\\": "src/"
-    }
+    },
+    "files": [
+      "src/helpers.php"
+    ]
   },
   "autoload-dev": {
     "psr-4": {

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * This helper function makes it easier to use a nonce for inline scripts in views.
+ * It matches the function used by similar package spatie/laravel-csp so libraries could check for it.
+ *
+ * Usage: <script nonce="{{ csp_nonce() }}">
+ */
+if (! function_exists('csp_nonce')) {
+    function csp_nonce() : string
+    {
+        return Bepsvpt\SecureHeaders\SecureHeaders::nonce();
+    }
+}

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+namespace Bepsvpt\SecureHeaders\Tests;
+
+use Bepsvpt\SecureHeaders\SecureHeaders;
+
+class HelpersTest extends TestCase
+{
+    /**
+     * @var string
+     */
+    protected $configPath = __DIR__ . '/../config/secure-headers.php';
+    
+    public function testCspNonce()
+    {
+        $nonce = csp_nonce();
+
+        $headers = (new SecureHeaders($this->config()))->headers();
+
+        $this->assertArrayHasKey(
+            'Content-Security-Policy',
+            $headers
+        );
+
+        $this->assertSame(
+            sprintf("script-src 'nonce-%s'", $nonce),
+            $headers['Content-Security-Policy']
+        );
+    }
+
+    /**
+     * Get secure-headers config.
+     *
+     * @return array<mixed>
+     */
+    protected function config(): array
+    {
+        return require $this->configPath;
+    }
+}


### PR DESCRIPTION
I ran into the issue that some external libraries generate inline scripts which get blocked by my csp directive. Most importantly Laravel Ignition/Flare. People suggest to check for the helper function `csp_nonce`, which is offered by spatie/laravel-csp. In order to also make this work for your package I suggest to add this function by the same name. 
Furthermore the function makes it imho a little cleaner to use in views.