### PR TITLE
docs(config): add clarification for x-powered-by

### DIFF
--- a/config/secure-headers.php
+++ b/config/secure-headers.php
@@ -56,6 +56,11 @@ return [
      * X-Powered-By
      *
      * Note: it will not add to response header if the value is empty string.
+     *
+     * Also, verify that expose_php is turned Off in php.ini.
+     * Otherwise the header will still be included in the response.
+     *
+     * Reference: https://github.com/bepsvpt/secure-headers/issues/58#issuecomment-782332442
      */
 
     'x-powered-by' => '',


### PR DESCRIPTION
Add note that `x-powered-by` will still be set when `expose_php` is turned **On** in `php.ini`