### PR TITLE
Add Laravel 9 support

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -60,28 +60,43 @@ jobs:
       fail-fast: false
 
       matrix:
-        laravel: ['8.0', '7.0', '6.0', '5.8.0', '5.7.0', '5.6.0', '5.5.0', '5.4.0', '5.3.0', '5.2.0', '5.1.0']
-        php: ['8.0', '7.4', '7.3', '7.2', '7.1', '7.0']
+        laravel: ['9.0', '8.0', '7.0', '6.0', '5.8.0', '5.7.0', '5.6.0', '5.5.0', '5.4.0', '5.3.0', '5.2.0', '5.1.0']
+        php: ['8.1', '8.0', '7.4', '7.3', '7.2', '7.1', '7.0']
         os: [ubuntu-latest, windows-latest, macOS-latest]
         exclude:
           - { laravel: '5.1.0', php: '8.0' }
+          - { laravel: '5.1.0', php: '8.1' }
           - { laravel: '5.2.0', php: '8.0' }
+          - { laravel: '5.2.0', php: '8.1' }
           - { laravel: '5.3.0', php: '8.0' }
+          - { laravel: '5.3.0', php: '8.1' }
           - { laravel: '5.4.0', php: '8.0' }
+          - { laravel: '5.4.0', php: '8.1' }
           - { laravel: '5.5.0', php: '8.0' }
+          - { laravel: '5.5.0', php: '8.1' }
           - { laravel: '5.6.0', php: '7.0' }
           - { laravel: '5.6.0', php: '8.0' }
+          - { laravel: '5.6.0', php: '8.1' }
           - { laravel: '5.7.0', php: '7.0' }
           - { laravel: '5.7.0', php: '8.0' }
+          - { laravel: '5.7.0', php: '8.1' }
           - { laravel: '5.8.0', php: '7.0' }
           - { laravel: '5.8.0', php: '8.0' }
+          - { laravel: '5.8.0', php: '8.1' }
           - { laravel: '6.0', php: '7.0' }
           - { laravel: '6.0', php: '7.1' }
+          - { laravel: '6.0', php: '8.1' }
           - { laravel: '7.0', php: '7.0' }
           - { laravel: '7.0', php: '7.1' }
+          - { laravel: '7.0', php: '8.1' }
           - { laravel: '8.0', php: '7.0' }
           - { laravel: '8.0', php: '7.1' }
           - { laravel: '8.0', php: '7.2' }
+          - { laravel: '9.0', php: '7.0' }
+          - { laravel: '9.0', php: '7.1' }
+          - { laravel: '9.0', php: '7.2' }
+          - { laravel: '9.0', php: '7.3' }
+          - { laravel: '9.0', php: '7.4' }
 
     steps:
       - uses: actions/checkout@v2

--- a/DOCS.md
+++ b/DOCS.md
@@ -77,3 +77,4 @@ If you want to run testing, make sure you have the corresponding package version
 |   6.x   |    4.x    |   8.4   |        7.2.0        |
 |   7.x   |    5.x    |   8.4   |        7.2.5        |
 |   8.x   |    6.x    |   9.4   |         7.3         |
+|   9.x   |    7.x    |   9.4   |         8.0         |

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add security related headers to HTTP response. The package includes Service Prov
 
 ### Supported Laravel Version
 
-5.1 ~ 8.x
+5.1 ~ 9.x
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,8 @@
 {
   "name": "bepsvpt/secure-headers",
-  "type": "library",
   "description": "Add security related headers to HTTP response. The package includes Service Providers for easy Laravel integration.",
+  "license": "MIT",
+  "type": "library",
   "keywords": [
     "laravel",
     "header",
@@ -14,40 +15,29 @@
     "referrer-policy",
     "content-security-policy"
   ],
-  "homepage": "https://github.com/bepsvpt/secure-headers",
-  "license": "MIT",
   "authors": [
     {
       "name": "bepsvpt",
       "email": "og7lsrszah6y3lz@infinitefa.email"
     }
   ],
+  "homepage": "https://github.com/bepsvpt/secure-headers",
   "require": {
     "php": "^7.0 || ^8.0",
-    "illuminate/support": "~5.1 || ~6.0 || ~7.0 || ~8.0"
+    "illuminate/support": "~5.1 || ~6.0 || ~7.0 || ~8.0 || ~9.0"
   },
   "require-dev": {
     "ext-json": "*",
     "ext-xdebug": "*",
-    "orchestra/testbench": "~3.1 || ~4.0 || ~5.0 || ~6.0"
+    "orchestra/testbench": "~3.1 || ~4.0 || ~5.0 || ~6.0 || ~7.0"
   },
   "suggest": {
     "friendsofphp/php-cs-fixer": "Coding style fixer",
     "phpstan/phpstan": "Static analysis tool",
     "phpunit/phpunit": "PHP unit testing framework"
   },
-  "config": {
-    "optimize-autoloader": true,
-    "preferred-install": "dist",
-    "sort-packages": true
-  },
-  "extra": {
-    "laravel": {
-      "providers": [
-        "Bepsvpt\\SecureHeaders\\SecureHeadersServiceProvider"
-      ]
-    }
-  },
+  "minimum-stability": "dev",
+  "prefer-stable": true,
   "autoload": {
     "psr-4": {
       "Bepsvpt\\SecureHeaders\\": "src/"
@@ -61,6 +51,16 @@
       "Bepsvpt\\SecureHeaders\\Tests\\": "tests/"
     }
   },
-  "minimum-stability": "dev",
-  "prefer-stable": true
+  "config": {
+    "optimize-autoloader": true,
+    "preferred-install": "dist",
+    "sort-packages": true
+  },
+  "extra": {
+    "laravel": {
+      "providers": [
+        "Bepsvpt\\SecureHeaders\\SecureHeadersServiceProvider"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
Adds support for Laravel 9 (including tests and documentation). Should close #68 .

Some notes:
- My first attempt had the wrong configuration for the version matrix and it has spend more of your Github Action minutes than is really necessary. Sorry for that!
- The updates to the laravel/php-version matrix are based on the support versions documented on https://laravel.com/docs/9.x/releases#support-policy. 
- The composer.json file is shuffled because it failed the `composer-normalise` checks

If there is anything I can do to get this reviewed/tested/merged/deployed, let me know 🙂 