### PR TITLE
support cross origin policy headers, fixes #60

### DIFF
--- a/config/secure-headers.php
+++ b/config/secure-headers.php
@@ -87,6 +87,33 @@ return [
     'referrer-policy' => 'no-referrer',
 
     /*
+     * Cross-Origin-Embedder-Policy
+     *
+     * Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy
+     *
+     * Available Value: 'unsafe-none', 'require-corp'
+     */
+    'cross-origin-embedder-policy' => 'unsafe-none',
+
+    /*
+     * Cross-Origin-Opener-Policy
+     *
+     * Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy
+     *
+     * Available Value: 'unsafe-none', 'same-origin-allow-popups', 'same-origin'
+     */
+    'cross-origin-opener-policy' => 'unsafe-none',
+
+    /*
+     * Cross-Origin-Resource-Policy
+     *
+     * Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy
+     *
+     * Available Value: 'same-site', 'same-origin', 'cross-origin'
+     */
+    'cross-origin-resource-policy' => 'cross-origin',
+
+    /*
      * Clear-Site-Data
      *
      * Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data

--- a/src/SecureHeaders.php
+++ b/src/SecureHeaders.php
@@ -230,6 +230,9 @@ class SecureHeaders
             'X-XSS-Protection' => $this->config['x-xss-protection'],
             'Referrer-Policy' => $this->config['referrer-policy'],
             'Server' => $this->config['server'],
+            'Cross-Origin-Embedder-Policy' => $this->config['cross-origin-embedder-policy'] ?? '',
+            'Cross-Origin-Opener-Policy' => $this->config['cross-origin-opener-policy'] ?? '',
+            'Cross-Origin-Resource-Policy' => $this->config['cross-origin-resource-policy'] ?? '',
         ]);
     }
 

--- a/tests/SecureHeadersTest.php
+++ b/tests/SecureHeadersTest.php
@@ -275,6 +275,28 @@ final class SecureHeadersTest extends TestCase
         );
     }
 
+    public function testCrossOriginPolicy()
+    {
+        $config = $this->config();
+
+        $config['cross-origin-resource-policy'] = 'same-origin';
+
+        $headers = (new SecureHeaders($config))->headers();
+
+        $this->assertArrayHasKey('Cross-Origin-Resource-Policy', $headers);
+
+        $this->assertSame('same-origin', $headers['Cross-Origin-Resource-Policy']);
+
+        // ensure backward compatibility
+
+        unset($config['cross-origin-resource-policy']);
+
+        $this->assertArrayNotHasKey(
+            'Cross-Origin-Resource-Policy',
+            (new SecureHeaders($config))->headers()
+        );
+    }
+
     /**
      * Get secure-headers config.
      *


### PR DESCRIPTION
Support the following cross origin policy headers: (fixes #60)
- `Cross-Origin-Embedder-Policy`: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy
- `Cross-Origin-Opener-Policy`: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy
- `Cross-Origin-Resource-Policy`: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy