### PR TITLE
Disable x-xss-protection by default

### DIFF
--- a/config/secure-headers.php
+++ b/config/secure-headers.php
@@ -73,7 +73,7 @@ return [
      * Available Value: '1', '0', '1; mode=block'
      */
 
-    'x-xss-protection' => '1; mode=block',
+    'x-xss-protection' => '',
 
     /*
      * Referrer-Policy


### PR DESCRIPTION
OWASP's recommendation is to use a Content Security Policy (CSP) that disables the use of inline JavaScript, and to not set the X-XSS-Protection header or explicitly turn it off.

> WARNING: Even though this header can protect users of older web browsers that don't yet support CSP, in some cases, this header can create XSS vulnerabilities in otherwise safe websites [source](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection).

https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#x-xss-protection