### PR TITLE
Update removeNonce parameters types

### DIFF
--- a/src/SecureHeaders.php
+++ b/src/SecureHeaders.php
@@ -317,7 +317,7 @@ class SecureHeaders
      *
      * @return void
      */
-    public static function removeNonce(string $target = null, string $nonce = null)
+    public static function removeNonce(?string $target = null, ?string $nonce = null)
     {
         if ($target === null) {
             self::$nonces['script'] = self::$nonces['style'] = [];


### PR DESCRIPTION
Fix PHP 8.4 deprecated warning:

Bepsvpt\SecureHeaders\SecureHeaders::removeNonce(): Implicitly marking parameter $target as nullable is deprecated, the explicit nullable type must be used instead in /vendor/bepsvpt/secure-headers/src/SecureHeaders.php on line 320