### PR TITLE
Add wasm support for CSP

### DIFF
--- a/config/secure-headers.php
+++ b/config/secure-headers.php
@@ -765,6 +765,8 @@ return [
 
             'unsafe-eval' => false,
 
+            'wasm-unsafe-eval' => false,
+
             // https://www.w3.org/TR/CSP3/#unsafe-hashes-usage
             'unsafe-hashes' => false,
 

--- a/src/Builders/ContentSecurityPolicyBuilder.php
+++ b/src/Builders/ContentSecurityPolicyBuilder.php
@@ -110,6 +110,7 @@ final class ContentSecurityPolicyBuilder extends Builder
             'self' => true,
             'unsafe-inline' => true,
             'unsafe-eval' => true,
+            'wasm-unsafe-eval' => true,
             'unsafe-hashes' => true,
             'strict-dynamic' => true,
             'report-sample' => true,


### PR DESCRIPTION
TL;DR: add `wasm-unsafe-eval` support to the CSP.

I was wondering why when the CSP is active my WASM scripts were not running. I traced it back to here. :)

https://search.brave.com/search?q=CompileError%3A+WebAssembly.instantiateStreaming%28%29%3A+Compiling+or+instantiating+WebAssembly+module+violates+the+following+Content+Security+policy+directive+because+%27unsafe-eval%27+is+not+an+allowed+source+of+script+in+the+following+Content+Security+Policy+directive&summary=1&conversation=0956076040ad4c84860416b60f5fd14daa22


Official documentation: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/script-src#unsafe_webassembly_execution
